### PR TITLE
feat: support loading gtag.js from proxy address

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ReactGA.event({
 | GA_MEASUREMENT_ID   | `string` Required                                                                                                       |
 | options.nonce       | `string` Optional Used for Content Security Policy (CSP) [more](https://developers.google.com/tag-manager/web/csp)      |
 | options.testMode    | `boolean` Default false                                                                                                 |
+| options.gaAddress   | `string` Optional If you are self-hosting your `gtag.js`, you can specify the URL for it here.                          |
 | options.gaOptions   | `object` Optional [Reference](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference) |
 | options.gtagOptions | `object` Optional                                                                                                       |
 

--- a/src/ga4.js
+++ b/src/ga4.js
@@ -78,7 +78,7 @@ export class GA4 {
     this._gtag(...args);
   }
 
-  _loadGA = (GA_MEASUREMENT_ID, nonce) => {
+  _loadGA = (GA_MEASUREMENT_ID, nonce, options) => {
     if (typeof window === "undefined" || typeof document === "undefined") {
       return;
     }
@@ -87,7 +87,11 @@ export class GA4 {
       // Global Site Tag (gtag.js) - Google Analytics
       const script = document.createElement("script");
       script.async = true;
-      script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+      if (options && options.gaAddress) {
+        script.src = `${options.gaAddress}?id=${GA_MEASUREMENT_ID}`;
+      } else {
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+      }
       if (nonce) {
         script.setAttribute("nonce", nonce);
       }
@@ -153,6 +157,7 @@ export class GA4 {
    * @param {Object} [options]
    * @param {string} [options.nonce]
    * @param {boolean} [options.testMode=false]
+   * @param {string} [options.gaAddress='']
    * @param {GaOptions|any} [options.gaOptions]
    * @param {Object} [options.gtagOptions] New parameter
    */
@@ -171,7 +176,7 @@ export class GA4 {
     this._testMode = testMode;
 
     if (!testMode) {
-      this._loadGA(this._currentMeasurementId, nonce);
+      this._loadGA(this._currentMeasurementId, nonce, options);
     }
     if (!this.isInitialized) {
       this._gtag("js", new Date());

--- a/types/ga4.d.ts
+++ b/types/ga4.d.ts
@@ -44,7 +44,7 @@ export class GA4 {
     _queueGtag: any[];
     _gtag: (...args: any[]) => void;
     gtag(...args: any[]): void;
-    _loadGA: (GA_MEASUREMENT_ID: any, nonce: any) => void;
+    _loadGA: (GA_MEASUREMENT_ID: any, nonce: any, options: any) => void;
     _toGtagOptions: (gaOptions: any) => {};
     /**
      *
@@ -52,12 +52,14 @@ export class GA4 {
      * @param {Object} [options]
      * @param {string} [options.nonce]
      * @param {boolean} [options.testMode=false]
+     * @param {string} [options.gaAddress='']
      * @param {GaOptions|any} [options.gaOptions]
      * @param {Object} [options.gtagOptions] New parameter
      */
     initialize: (GA_MEASUREMENT_ID: InitOptions[] | string, options?: {
         nonce?: string;
         testMode?: boolean;
+        gaAddress?: string;
         gaOptions?: GaOptions | any;
         gtagOptions?: any;
     }) => void;


### PR DESCRIPTION
From [#16](https://github.com/codler/react-ga4/issues/16)

Due to some well-known reasons, `https://www.googletagmanager.com/gtag/js` may not be accessible in China. 

So add the `gaAddress` option (like [react-ga](https://github.com/react-ga/react-ga#example)) in the `ReactGA.initialize()` method to load the gtag.js from the proxy address.