### PR TITLE
Extend ua event options types

### DIFF
--- a/types/ga4.d.ts
+++ b/types/ga4.d.ts
@@ -132,9 +132,9 @@ export type UaEventOptions = {
 };
 
 export type ItemOptions = {
-  item_name: string;
-  item_category: string;
-  item_id: string;
+  item_name?: string;
+  item_category?: string;
+  item_id?: string;
   price: number;
   affiliation?: string;
   quantity: number;

--- a/types/ga4.d.ts
+++ b/types/ga4.d.ts
@@ -36,87 +36,114 @@
  * @property {Object} [gtagOptions] New parameter
  */
 export class GA4 {
-    reset: () => void;
-    isInitialized: boolean;
-    _testMode: boolean;
-    _hasLoadedGA: boolean;
-    _isQueuing: boolean;
-    _queueGtag: any[];
-    _gtag: (...args: any[]) => void;
-    gtag(...args: any[]): void;
-    _loadGA: (GA_MEASUREMENT_ID: any, nonce: any, gtagUrl?: string) => void;
-    _toGtagOptions: (gaOptions: any) => {};
-    /**
-     *
-     * @param {InitOptions[]|string} GA_MEASUREMENT_ID
-     * @param {Object} [options]
-     * @param {string} [options.nonce]
-     * @param {boolean} [options.testMode=false]
-     * @param {string} [options.gtagUrl=https://www.googletagmanager.com/gtag/js]
-     * @param {GaOptions|any} [options.gaOptions]
-     * @param {Object} [options.gtagOptions] New parameter
-     */
-    initialize: (GA_MEASUREMENT_ID: InitOptions[] | string, options?: {
-        nonce?: string;
-        testMode?: boolean;
-        gtagUrl?: string;
-        gaOptions?: GaOptions | any;
-        gtagOptions?: any;
-    }) => void;
-    _currentMeasurementId: string;
-    set: (fieldsObject: any) => void;
-    _gaCommandSendEvent: (eventCategory: any, eventAction: any, eventLabel: any, eventValue: any, fieldsObject: any) => void;
-    _gaCommandSendEventParameters: (...args: any[]) => void;
-    _gaCommandSendTiming: (timingCategory: any, timingVar: any, timingValue: any, timingLabel: any) => void;
-    _gaCommandSendPageview: (page: any, fieldsObject: any) => void;
-    _gaCommandSendPageviewParameters: (...args: any[]) => void;
-    _gaCommandSend: (...args: any[]) => void;
-    _gaCommandSet: (...args: any[]) => void;
-    _gaCommand: (command: any, ...args: any[]) => void;
-    ga: (...args: any[]) => any;
-    /**
-     * @param {UaEventOptions|string} optionsOrName
-     * @param {Object} [params]
-     */
-    event: (optionsOrName: UaEventOptions | string, params?: any) => void;
-    send: (fieldObject: any) => void;
+  reset: () => void;
+  isInitialized: boolean;
+  _testMode: boolean;
+  _hasLoadedGA: boolean;
+  _isQueuing: boolean;
+  _queueGtag: any[];
+  _gtag: (...args: any[]) => void;
+  gtag(...args: any[]): void;
+  _loadGA: (GA_MEASUREMENT_ID: any, nonce: any, gtagUrl?: string) => void;
+  _toGtagOptions: (gaOptions: any) => {};
+  /**
+   *
+   * @param {InitOptions[]|string} GA_MEASUREMENT_ID
+   * @param {Object} [options]
+   * @param {string} [options.nonce]
+   * @param {boolean} [options.testMode=false]
+   * @param {string} [options.gtagUrl=https://www.googletagmanager.com/gtag/js]
+   * @param {GaOptions|any} [options.gaOptions]
+   * @param {Object} [options.gtagOptions] New parameter
+   */
+  initialize: (
+    GA_MEASUREMENT_ID: InitOptions[] | string,
+    options?: {
+      nonce?: string;
+      testMode?: boolean;
+      gtagUrl?: string;
+      gaOptions?: GaOptions | any;
+      gtagOptions?: any;
+    }
+  ) => void;
+  _currentMeasurementId: string;
+  set: (fieldsObject: any) => void;
+  _gaCommandSendEvent: (
+    eventCategory: any,
+    eventAction: any,
+    eventLabel: any,
+    eventValue: any,
+    fieldsObject: any
+  ) => void;
+  _gaCommandSendEventParameters: (...args: any[]) => void;
+  _gaCommandSendTiming: (
+    timingCategory: any,
+    timingVar: any,
+    timingValue: any,
+    timingLabel: any
+  ) => void;
+  _gaCommandSendPageview: (page: any, fieldsObject: any) => void;
+  _gaCommandSendPageviewParameters: (...args: any[]) => void;
+  _gaCommandSend: (...args: any[]) => void;
+  _gaCommandSet: (...args: any[]) => void;
+  _gaCommand: (command: any, ...args: any[]) => void;
+  ga: (...args: any[]) => any;
+  /**
+   * @param {UaEventOptions|string} optionsOrName
+   * @param {Object} [params]
+   */
+  event: (optionsOrName: UaEventOptions | string, params?: any) => void;
+  send: (fieldObject: any) => void;
 }
 declare const _default: GA4;
 export default _default;
 export type GaOptions = {
-    cookieUpdate?: boolean;
-    /**
-     * Default two years
-     */
-    cookieExpires?: number;
-    cookieDomain?: string;
-    cookieFlags?: string;
-    userId?: string;
-    clientId?: string;
-    anonymizeIp?: boolean;
-    contentGroup1?: string;
-    contentGroup2?: string;
-    contentGroup3?: string;
-    contentGroup4?: string;
-    contentGroup5?: string;
-    allowAdFeatures?: boolean;
-    allowAdPersonalizationSignals?: boolean;
-    nonInteraction?: boolean;
-    page?: string;
+  cookieUpdate?: boolean;
+  /**
+   * Default two years
+   */
+  cookieExpires?: number;
+  cookieDomain?: string;
+  cookieFlags?: string;
+  userId?: string;
+  clientId?: string;
+  anonymizeIp?: boolean;
+  contentGroup1?: string;
+  contentGroup2?: string;
+  contentGroup3?: string;
+  contentGroup4?: string;
+  contentGroup5?: string;
+  allowAdFeatures?: boolean;
+  allowAdPersonalizationSignals?: boolean;
+  nonInteraction?: boolean;
+  page?: string;
 };
 export type UaEventOptions = {
-    action: string;
-    category: string;
-    label?: string;
-    value?: number;
-    nonInteraction?: boolean;
-    transport?: ('beacon' | 'xhr' | 'image');
+  action: string;
+  category: string;
+  label?: string;
+  transaction_id?: string;
+  value?: number;
+  tax?: number;
+  currency?: string;
+  nonInteraction?: boolean;
+  transport?: "beacon" | "xhr" | "image";
+  items?: ItemOptions[];
+};
+
+export type ItemOptions = {
+  item_name: string;
+  item_category: string;
+  item_id: string;
+  price: number;
+  affiliation?: string;
+  quantity: number;
 };
 export type InitOptions = {
-    trackingId: string;
-    gaOptions?: GaOptions | any;
-    /**
-     * New parameter
-     */
-    gtagOptions?: any;
+  trackingId: string;
+  gaOptions?: GaOptions | any;
+  /**
+   * New parameter
+   */
+  gtagOptions?: any;
 };


### PR DESCRIPTION
Add types to be able to send purchase events as below

```
ReactGA.event('purchase', {
      category: 'purchase',
      action: 'action',
      transaction_id: 'transaction_id', // optional
      value: 0.00, // optional, must be a number
      tax: 0.00,  // optional, must be a number
      currency: 'USD',
      items: [ {
        item_name: string,  // optional
        item_id: string,  // optional
        item_category: string,  // optional
        price: 0.00, // must be a number
        quantity: 1,
        affiliation: string, // optional
      } ], // optional array of items
      transport: 'xhr',
    });
```