### PR TITLE
Gtag script append in header

### DIFF
--- a/src/ga4.js
+++ b/src/ga4.js
@@ -95,7 +95,7 @@ export class GA4 {
       if (nonce) {
         script.setAttribute("nonce", nonce);
       }
-      document.body.appendChild(script);
+      document.head.appendChild(script);
 
       window.dataLayer = window.dataLayer || [];
       window.gtag = function gtag() {


### PR DESCRIPTION
Currently GTAG script is being loaded into document.body but google recommends it to load inside head only. Due to script getting load in body many fields will be getting as not-set when setting up utm source etc in report. 