### PR TITLE
Support titleCase option when initializing

### DIFF
--- a/src/ga4.js
+++ b/src/ga4.js
@@ -177,9 +177,11 @@ export class GA4 {
       gtagOptions,
       nonce,
       testMode = false,
+      titleCase = true,
       gtagUrl,
     } = options;
     this._testMode = testMode;
+    this._titleCase = titleCase;
 
     if (!testMode) {
       this._loadGA(this._currentMeasurementId, nonce, gtagUrl);
@@ -417,13 +419,13 @@ export class GA4 {
       // Required Fields
       const fieldObject = {
         hitType: "event",
-        eventCategory: format(category),
-        eventAction: format(action),
+        eventCategory: format(category, this._titleCase),
+        eventAction: format(action, this._titleCase),
       };
 
       // Optional Fields
       if (label) {
-        fieldObject.eventLabel = format(label);
+        fieldObject.eventLabel = format(label, this._titleCase);
       }
 
       if (typeof value !== "undefined") {

--- a/src/ga4.test.js
+++ b/src/ga4.test.js
@@ -60,6 +60,50 @@ describe("GA4", () => {
       expect(gtag).toHaveBeenCalledTimes(0);
     });
 
+    it("initialize() with default titleCase true", () => {
+      // Given
+      const options = {};
+
+      // When
+      GA4.initialize(GA_MEASUREMENT_ID, options);
+      GA4.event({
+        action: "action_name",
+        category: "category_name",
+        label: "label_name",
+      });
+
+      // Then
+      expect(gtag).toHaveBeenNthCalledWith(1, "js", newDate);
+      expect(gtag).toHaveBeenNthCalledWith(2, "config", GA_MEASUREMENT_ID);
+      expect(gtag).toHaveBeenNthCalledWith(3, "event", "Action_name", {
+        "event_category": "Category_name",
+        "event_label": "Label_name",
+      });
+    });
+
+    it("initialize() with titleCase false", () => {
+      // Given
+      const options = {
+        titleCase: false,
+      };
+
+      // When
+      GA4.initialize(GA_MEASUREMENT_ID, options);
+      GA4.event({
+        action: "action_name",
+        category: "category_name",
+        label: "label_name",
+      });
+
+      // Then
+      expect(gtag).toHaveBeenNthCalledWith(1, "js", newDate);
+      expect(gtag).toHaveBeenNthCalledWith(2, "config", GA_MEASUREMENT_ID);
+      expect(gtag).toHaveBeenNthCalledWith(3, "event", "action_name", {
+        "event_category": "category_name",
+        "event_label": "label_name",
+      });
+    });
+
     it("initialize() multiple products", () => {
       // Given
       const GA_MEASUREMENT_ID2 = "GA_MEASUREMENT_ID2";


### PR DESCRIPTION
- Closes https://github.com/codler/react-ga4/issues/54

Adds support for sending event data, etc. without automatically title casing the values. Continues to default to the behavior of title casing for backward compatibility.