### PR TITLE
fix: add ESM exports to support consistent CJS interop in Vite/Rolldown

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,18 @@ const { NODE_ENV } = process.env;
 
 const options = NODE_ENV === "test" ? { targets: { node: "current" } } : {};
 
-module.exports = {
-  presets: [["@babel/preset-env", options]],
+module.exports = (api) => {
+  const isESM = api.env("esm");
+
+  return {
+    presets: [
+      [
+        "@babel/preset-env",
+        {
+          ...options,
+          modules: isESM ? false : "auto",
+        },
+      ],
+    ],
+  };
 };

--- a/package.json
+++ b/package.json
@@ -2,10 +2,20 @@
   "name": "react-ga4",
   "version": "2.1.0",
   "description": "React Google Analytics 4",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "scripts": {
-    "build": "NODE_ENV=production babel src -d dist",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "NODE_ENV=production babel src -d dist/cjs",
+    "build:esm": "NODE_ENV=production BABEL_ENV=esm babel src -d dist/esm",
     "postbuild": "tsc src/index.js --declaration --allowJs --emitDeclarationOnly --outDir types",
     "prepublishOnly": "npm run build && npm test",
     "test": "NODE_ENV=test jest"

--- a/src/ga4.js
+++ b/src/ga4.js
@@ -1,5 +1,5 @@
-import gtag from "./gtag";
-import format from "./format";
+import gtag from "./gtag.js";
+import format from "./format.js";
 
 /*
 Links

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import ga4, { GA4 } from "./ga4";
+import ga4, { GA4 } from "./ga4.js";
 
 export const ReactGAImplementation = GA4;
 


### PR DESCRIPTION
## Problem

With the introduction of consistent CJS interop in Vite (powered by Rolldown),
projects using `"type": "module"` receive `module.exports` as the default import
instead of `module.exports.default`.

This causes `react-ga4`'s default import to return the entire exports object
rather than the GA4 instance, breaking `ga4.initialize()` and other methods.

See: https://rolldown.rs/in-depth/bundling-cjs#ambiguous-default-import-from-cjs-modules

## Solution

Add an ESM entry point via the `exports` field in `package.json`,
so bundlers can resolve the proper ESM version directly.

## Changes

- Modified `babel.config.js` to support ESM build (`modules: false` when `BABEL_ENV=esm`)
- Added `.js` extensions to relative imports in `src/` for Node.js ESM compatibility
- CJS build output moved to `dist/cjs/`
- ESM build output added at `dist/esm/`
- Added `exports`, `module` fields to `package.json`